### PR TITLE
Disable pet dragging while placing items

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -271,9 +271,20 @@ export default class Demo extends Phaser.Scene {
 
   private setUiBlocked(blocked: boolean) {
     this.uiBlocked = blocked;
-    this.input.setDraggable(this.pet, !blocked);
+    this.syncPetDragState();
 
     if (blocked) {
+      this.isPetDragging = false;
+      this.petDragConsumed = false;
+    }
+  }
+
+  private syncPetDragState() {
+    const canDragPet = !this.uiBlocked && !this.selectedItem;
+
+    this.input.setDraggable(this.pet, canDragPet);
+
+    if (!canDragPet) {
       this.isPetDragging = false;
       this.petDragConsumed = false;
     }
@@ -626,6 +637,7 @@ export default class Demo extends Phaser.Scene {
     this.stopIdleMotion();
 
     this.selectedItem = item;
+    this.syncPetDragState();
 
     if (this.placementPreview) {
       this.placementPreview.destroy();


### PR DESCRIPTION
### What
When an item is selected for placement, disable pet dragging so taps/drags are reserved for placement interactions (especially on mobile).

### Why
Prevents accidental pet drags when the player intends to place/cancel/select items.

### How
- Added `syncPetDragState()` to keep pet draggable only when the UI is ready (not blocked, no selected item).
- Call it from `setUiBlocked()` and when entering item placement (`pickItem`).

### Testing
- `npm run build`
