### PR TITLE
fix: clamp item placement to yard bounds

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -82,7 +82,8 @@ export default class Demo extends Phaser.Scene {
 
       const { x, y, isValid } = this.getPlacementTarget(
         pointer.worldX,
-        pointer.worldY
+        pointer.worldY,
+        this.placementPreview
       );
       this.placementPreview.setPosition(x, y);
 
@@ -306,18 +307,41 @@ export default class Demo extends Phaser.Scene {
     }
   }
 
-  private getClampedPetPosition(x: number, y: number) {
-    const halfWidth = this.pet.displayWidth / 2;
-    const halfHeight = this.pet.displayHeight / 2;
-
+  private getClampedPosition(
+    x: number,
+    y: number,
+    halfWidth: number,
+    halfHeight: number
+  ) {
     return {
       x: Phaser.Math.Clamp(x, halfWidth, GAME_WIDTH - halfWidth),
       y: Phaser.Math.Clamp(y, halfHeight, Math.min(TOOLBAR_TOP, GAME_HEIGHT) - halfHeight)
     };
   }
 
-  private getPlacementTarget(x: number, y: number) {
-    const clampedPosition = this.getClampedPetPosition(x, y);
+  private getClampedSpritePosition(
+    x: number,
+    y: number,
+    sprite: GameObjects.Sprite
+  ) {
+    return this.getClampedPosition(
+      x,
+      y,
+      sprite.displayWidth / 2,
+      sprite.displayHeight / 2
+    );
+  }
+
+  private getClampedPetPosition(x: number, y: number) {
+    return this.getClampedSpritePosition(x, y, this.pet);
+  }
+
+  private getPlacementTarget(
+    x: number,
+    y: number,
+    sprite: GameObjects.Sprite
+  ) {
+    const clampedPosition = this.getClampedSpritePosition(x, y, sprite);
 
     return {
       ...clampedPosition,
@@ -732,7 +756,8 @@ export default class Demo extends Phaser.Scene {
 
     const { x, y, isValid } = this.getPlacementTarget(
       pointer.worldX,
-      pointer.worldY
+      pointer.worldY,
+      this.placementPreview ?? this.selectedItem
     );
 
     if (!isValid) {


### PR DESCRIPTION
Summary
- Fix item placement clamping to use the item’s own bounds (preview + final placement), so items can’t be placed partially outside the yard.

Changes
- Refactor clamping into shared helpers and route placement validation through the preview/selected item sprite size.

Testing
- yarn -s build
